### PR TITLE
Add HERP IVA instruments

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/ExpPack/HERP/spaces/pod_internal.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/ExpPack/HERP/spaces/pod_internal.cfg
@@ -3,7 +3,7 @@ INTERNAL
 	name = HERPInternal
 	MODEL
 	{
-		model = UmbraSpaceIndustries/ExpPack/HERP/spaces/HERP_POD_IVA
+		model = SubPack/HERP/spaces/HERP_POD_IVA
 	}
 	MODULE
 	{
@@ -17,5 +17,54 @@ INTERNAL
 		position = 0,0.2045081,-0.4536073
 		rotation = 0.8660254,-5.963311E-08,-5.963311E-08,0.5
 		scale = 1,1,1
+	}
+	PROP
+	{
+		name = AltimeterThreeHands
+		position = -0.03735, 0.1747, -0.44
+		rotation = 0.8660254,-5.963311E-08,-5.963311E-08,0.5
+		scale = 0.33, 0.33, 0.33
+	}
+	PROP
+	{
+		name = RadarAltimeter
+		position = 0.0369, 0.172, -0.44
+		rotation = 0.8660254,-5.963311E-08,-5.963311E-08,0.5
+		scale = 0.33, 0.33, 0.33
+	}
+	PROP
+	{
+		name = VSI
+		position = -0.0542, 0.174, -0.433
+		rotation = 0.8660254,-5.963311E-08,-5.963311E-08,0.5
+		scale = 0.33, 0.33, 0.33
+	}
+	PROP
+	{
+		name = throttle
+		position = -0.0317, 0.197, -0.43
+		rotation = 0.8660254,-5.963311E-08,-5.963311E-08,0.5
+		scale = 0.1, 0.1, 0.1
+	}
+	PROP
+	{
+		name = AtmosphereDepth
+		position = 0.047, 0.174, -0.433
+		rotation = 0.8660254,-5.963311E-08,-5.963311E-08,0.5
+		scale = 0.33, 0.33, 0.33
+	}
+	PROP
+	{
+		name = IndicatorPanel
+		position = 0.036, 0.192, -0.43
+		rotation = 0.8660254,-5.963311E-08,-5.963311E-08,0.5
+		scale = 0.25, 0.25, 0.25
+	}
+	PROP
+	{
+		name = ledPanelSpeed
+		position = 0.0004664739, 0.166, -0.4339
+		rotation = 0.8660254,-5.963311E-08,-5.963311E-08,0.5
+		scale = 0.5, 0.5, 0.5
 	}
 }


### PR DESCRIPTION
Adds props to HERP command pod IVA. Tiny Throttle, Altimeter, ground radar, VSI.